### PR TITLE
Added camera configuration manager

### DIFF
--- a/rocon_rtsp_camera_relay/CMakeLists.txt
+++ b/rocon_rtsp_camera_relay/CMakeLists.txt
@@ -2,6 +2,7 @@ cmake_minimum_required(VERSION 2.8.3)
 project(rocon_rtsp_camera_relay)
 
 find_package(catkin REQUIRED COMPONENTS
+  camera_info_manager
   roscpp
   cv_bridge
   image_transport
@@ -14,7 +15,7 @@ find_package(OpenCV)
 catkin_package(
   INCLUDE_DIRS include
   LIBRARIES rocon_rtsp_camera_relay
-  CATKIN_DEPENDS roscpp cv_bridge image_transport sensor_msgs std_msgs
+  CATKIN_DEPENDS roscpp cv_bridge image_transport sensor_msgs std_msgs  camera_info_manager
   DEPENDS OpenCV
 )
 

--- a/rocon_rtsp_camera_relay/include/rocon_rtsp_camera_relay/rocon_rtsp_camera_relay.hpp
+++ b/rocon_rtsp_camera_relay/include/rocon_rtsp_camera_relay/rocon_rtsp_camera_relay.hpp
@@ -6,25 +6,27 @@
 #ifndef ROCON_RTSP_CAMERA_RELAY
 #define ROCON_RTSP_CAMERA_RELAY
 
-#include<ros/ros.h>
-#include<opencv2/opencv.hpp>
-#include<cv_bridge/cv_bridge.h>
+#include <ros/ros.h>
+#include <opencv2/opencv.hpp>
+#include <cv_bridge/cv_bridge.h>
 
-#include<std_msgs/String.h>
-#include<image_transport/image_transport.h>
-#include<sensor_msgs/image_encodings.h>
-#include<sensor_msgs/Image.h>
-#include<sensor_msgs/CameraInfo.h>
+#include <std_msgs/String.h>
+#include <image_transport/image_transport.h>
+#include <sensor_msgs/image_encodings.h>
+#include <sensor_msgs/Image.h>
+
+#include <camera_info_manager/camera_info_manager.h>
+#include <sensor_msgs/CameraInfo.h>
 
 namespace rocon {
 
 class RoconRtspCameraRelay {
   public:
-    RoconRtspCameraRelay(ros::NodeHandle& n);
+    RoconRtspCameraRelay(ros::NodeHandle& n, ros::NodeHandle& cnh);
     ~RoconRtspCameraRelay();
 
-    bool init(const std::string video_stream_url);
-    bool reset(const std::string video_stream_url);
+    bool init(const std::string video_stream_url, const std::string camera_config_url);
+    bool reset(const std::string video_stream_url, const std::string camera_config_url);
 
     void spin();
   
@@ -40,6 +42,11 @@ class RoconRtspCameraRelay {
     ros::Publisher pub_camera_info_;
     ros::Publisher pub_status_;
     ros::NodeHandle nh_;
+    
+    //For camera_info_manager, so this node can participate in image_proc pipelines
+    ros::NodeHandle camera_nh_;   // camera name space handle
+    std::string camera_name_;     // camera name
+    boost::shared_ptr<camera_info_manager::CameraInfoManager> cinfo_; //The manager
 };
 }
 

--- a/rocon_rtsp_camera_relay/launch/rtsp_camera_relay.launch
+++ b/rocon_rtsp_camera_relay/launch/rtsp_camera_relay.launch
@@ -2,5 +2,9 @@
   <arg name="video_stream_url" default="$(env ROCON_RTSP_CAMERA_RELAY_URL)"/>
   <node pkg="rocon_rtsp_camera_relay" name="rtsp_camera_relay" type="rocon_rtsp_camera_relay_node">
     <param name="video_stream_url"    value="$(arg video_stream_url)"/>
+    <param name="camera_name" value="overhead_cam"/>
+    <param name="camera_config_url" value="file:///$(find camera_cal)/overhead_camera_calibration.yaml"/>
   </node>
+
+  <node name="rectifier" pkg="image_proc" type="image_proc" ns="overhead_cam" respawn="true"/>
 </launch>

--- a/rocon_rtsp_camera_relay/package.xml
+++ b/rocon_rtsp_camera_relay/package.xml
@@ -11,11 +11,13 @@
   <license>BSD</license>
   <buildtool_depend>catkin</buildtool_depend>
   <build_depend>roscpp</build_depend>
+  <build_depend>camera_info_manager</build_depend>
   <build_depend>cv_bridge</build_depend>
   <build_depend>image_transport</build_depend>
   <build_depend>sensor_msgs</build_depend>
   <build_depend>std_msgs</build_depend>
   <run_depend>roscpp</run_depend>
+  <run_depend>camera_info_manager</run_depend>
   <run_depend>cv_bridge</run_depend>
   <run_depend>image_transport</run_depend>
   <run_depend>sensor_msgs</run_depend>

--- a/rocon_rtsp_camera_relay/src/main.cpp
+++ b/rocon_rtsp_camera_relay/src/main.cpp
@@ -10,13 +10,18 @@ int main (int argc, char** argv)
 {
   ros::init(argc, argv, "rtsp_camera_relay");
   ros::NodeHandle pnh("~");
-  std::string video_stream_url, user, password;
+  std::string video_stream_url, user, password, camera_name, camera_config_url;
 
   pnh.getParam("video_stream_url", video_stream_url);
 
-  rocon::RoconRtspCameraRelay rtsp(pnh);
+  //For camera configuration so that this camera can be calibrated
+  pnh.getParam("camera_name", camera_name);
+  pnh.getParam("camera_config_url", camera_config_url);
+  ros::NodeHandle camera_nh(camera_name);
+
+  rocon::RoconRtspCameraRelay rtsp(pnh, camera_nh);
   ROS_INFO("Rtsp Camera : Initialising..");
-  if(!rtsp.init(video_stream_url))
+  if(!rtsp.init(video_stream_url, camera_config_url))
   {
     ROS_ERROR("Rtsp Camera : Failed to initialise stream");
     return -1;

--- a/rocon_rtsp_camera_relay/src/rocon_rtsp_camera_relay.cpp
+++ b/rocon_rtsp_camera_relay/src/rocon_rtsp_camera_relay.cpp
@@ -7,12 +7,15 @@
 
 namespace rocon {
 
-RoconRtspCameraRelay::RoconRtspCameraRelay(ros::NodeHandle& n) : nh_(n)
+RoconRtspCameraRelay::RoconRtspCameraRelay(ros::NodeHandle& n, ros::NodeHandle& cnh) : 
+  nh_(n), camera_nh_(cnh), cinfo_(new camera_info_manager::CameraInfoManager(camera_nh_))
 {
-  image_transport::ImageTransport it(nh_);    
-  pub_video_ = it.advertise("image", 1);
-  pub_camera_info_ = nh_.advertise<sensor_msgs::CameraInfo>("camera_info", 1);
-  pub_status_ = nh_.advertise<std_msgs::String>("status", 1);
+  image_transport::ImageTransport it(camera_nh_);    
+  pub_video_ = it.advertise("image_raw", 1);
+  pub_camera_info_ = camera_nh_.advertise<sensor_msgs::CameraInfo>("camera_info", 1);
+  pub_status_ = camera_nh_.advertise<std_msgs::String>("status", 1);
+
+  //Load the camera information 
 }
 
 RoconRtspCameraRelay::~RoconRtspCameraRelay()
@@ -20,19 +23,31 @@ RoconRtspCameraRelay::~RoconRtspCameraRelay()
   vcap_.release();
 }
 
-bool RoconRtspCameraRelay::init(const std::string video_stream_url) {
+bool RoconRtspCameraRelay::init(const std::string video_stream_url, const std::string camera_config_url) {
   video_stream_address_ = video_stream_url;
 
+  //Attempt to load the calibration information
+  if (cinfo_->validateURL(camera_config_url))
+  {
+    cinfo_->loadCameraInfo(camera_config_url);
+    ROS_INFO("Loaded camera configuration from %s", camera_config_url.c_str());
+  }
+  else
+  {
+    ROS_WARN("Could not validate camera configuration from %s", camera_config_url.c_str());
+  }
+
+  //Attempt to open the video stream
   if (!vcap_.open(video_stream_address_)) 
     return false; 
   else
     return true;
 }
 
-bool RoconRtspCameraRelay::reset(const std::string video_stream_url)
+bool RoconRtspCameraRelay::reset(const std::string video_stream_url, const std::string camera_config_url)
 {
   vcap_.release();
-  return init(video_stream_url);
+  return init(video_stream_url, camera_config_url);
 }
 
 /*
@@ -46,6 +61,7 @@ void RoconRtspCameraRelay::convertCvToRosImg(const cv::Mat& mat, sensor_msgs::Im
   cv_img.image = mat;
   cv_img.toImageMsg(ros_img);
   ros_img.header.stamp = ros::Time::now();
+
   ci.header = ros_img.header;
   ci.width = ros_img.width;
   ci.height = ros_img.height;
@@ -57,7 +73,7 @@ void RoconRtspCameraRelay::convertCvToRosImg(const cv::Mat& mat, sensor_msgs::Im
 void RoconRtspCameraRelay::spin()
 {
   cv::Mat mat;
-  sensor_msgs::CameraInfo ci;
+  sensor_msgs::CameraInfo ci(*(new sensor_msgs::CameraInfo(cinfo_->getCameraInfo())));
   sensor_msgs::Image ros_img;
   std_msgs::String ros_str;
 


### PR DESCRIPTION
These changes add the ROS camera configuration manager so that the rocon_rtsp_camera_relay package can use the ROS image_proc nodes to provide rectified and debayered images (mostly handy to correct camera distortions for machine vision stuff). 

I haven't added checks for the image size or camera name yet, so the code won't warn you if you give it a configuration file for another camera or different image size. This usually results in obvious distortion of the image. 
